### PR TITLE
Ensure sendToBrowser() only send strings. (closes #79)

### DIFF
--- a/js/newTab.js
+++ b/js/newTab.js
@@ -95,11 +95,12 @@
       return stringifiedSites;
     },
 
-    sendToBrowser(type, data) {
+    sendToBrowser(command, msgData = "") {
+      var data = JSON.stringify(msgData);
       let event = new CustomEvent("NewTabCommand", {
         detail: {
-          command: type,
-          data: data
+          command,
+          data,
         }
       });
       document.dispatchEvent(event);


### PR DESCRIPTION
Must merge with https://github.com/mozilla/newtab-dev/pull/19
