### PR TITLE
Made little test server for local development

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -1,0 +1,25 @@
+#! /usr/bin/env node
+
+/*jshint node:true*/
+"use strict";
+const path = require("path");
+const express = require("express");
+const app = express();
+const staticSite = path.resolve(__dirname, "../src/");
+const pathToSW = staticSite + "/js/sw.js";
+
+const server = app.listen(8000, () => {
+  let port = server.address().port;
+  console.log(`Server at http://localhost:${port}`);
+});
+
+app.use(express.static(staticSite, {
+  maxAge: "1d",
+  setHeaders: function(res, path) {
+    if (path === pathToSW) {
+      res.setHeader("Service-Worker-Allowed", "/");
+    }
+  }
+}));
+
+app.disable("x-powered-by");

--- a/package.json
+++ b/package.json
@@ -36,9 +36,11 @@
     "mocha": "^2.2.5",
     "mozilla-download": "^1.1.1",
     "requirejs": "^2.1.20",
-    "webpack": "^1.12.2"
+    "webpack": "^1.12.2",
+    "express": "^4.13.3"
   },
   "scripts": {
+    "server": "bin/server.js",
     "generate-offline-files": "bin/generate-offline-files.js",
     "karma": "karma start --single-run",
     "test": "npm run karma",


### PR DESCRIPTION
- When we move the service worker to the JS folder we will need to set a special header (Service-Worker-Allowed) to make it work again. 
- We can build on this little express server as we go, for better emulating the cache directives we will use on our actual site. 

@k88hudson r? 
