### PR TITLE
[#163] Generate locale dirs

### DIFF
--- a/bin/generate-directories.js
+++ b/bin/generate-directories.js
@@ -1,0 +1,87 @@
+#! /usr/bin/env node
+"use strict";
+const glob = require("glob");
+const path = require("path");
+const fs = require("fs-extra")
+
+const generateHtml = require("./generate-html");
+const generateLocaleData = require("./generate-locale-data");
+
+const PAGE_TITLE_KEY = "newtab-pageTitle";
+const JS_FILENAME = "locale-data.js";
+
+const defaults = {
+  outputPath: path.join(__dirname, "../build"),
+  i10nPath: path.join(__dirname, "../l10n"),
+  staticPath: path.join(__dirname, "../www"),
+  channels: ["nightly", "aurora", "beta", "release", "esr"]
+}
+
+class DirectoryGenerator {
+  constructor(rawOptions) {
+    const options = Object.assign({}, defaults, rawOptions);
+    Object.keys(options).forEach(key => this[key] = options[key]);
+
+    this.locales = glob.sync(`${this.i10nPath}/*/`).map(file => path.relative(this.i10nPath, file));
+    this.staticFiles = glob.sync(`${this.staticPath}/**/*`).map(file => path.relative(this.staticPath, file));
+  }
+
+  outputFiles(options) {
+    const js = options.js;
+    const html = options.html;
+    const dirPath = options.dirPath;
+
+    const jsPath = path.join(dirPath, JS_FILENAME);
+    const htmlPath = path.join(dirPath, "index.html");
+
+    this.staticFiles.forEach(file => {
+      fs.copySync(path.join(this.staticPath, file), path.join(dirPath, file));
+    });
+
+    fs.outputFileSync(jsPath, js, "utf8");
+    fs.outputFileSync(htmlPath, html, "utf8");
+  }
+
+  generateForLocale(locale) {
+    const localeData = generateLocaleData(locale);
+    const messages = localeData.messages;
+    const js = localeData.fileString;
+    const html = generateHtml({
+      title: messages[PAGE_TITLE_KEY] || "New Tab",
+      locale,
+      paths: {
+        localeData: JS_FILENAME,
+        js: "main.js",
+        css: "main.css"
+        // TODO prerender
+      }
+    });
+
+    this.channels.forEach(channel => {
+      this.outputFiles({html, js, dirPath: path.join(this.outputPath, channel, locale)});
+    });
+  }
+
+  run() {
+    this.locales.forEach(this.generateForLocale.bind(this));
+  }
+
+}
+
+module.exports = DirectoryGenerator;
+
+if (require.main === module)  {
+  // called from command line
+  const args = require("minimist")(process.argv.slice(2), {alias: {
+    outputPath: ['o', 'output'],
+    i10nPath: ['i', 'input'],
+    staticPath: ['s', 'static'],
+    channels: ['c']
+  }});
+  const generator = new DirectoryGenerator(args);
+  console.log('Generating directories...');
+  generator.run();
+  console.log(`Finished generating directories for:
+  ${generator.channels.length} channels
+  ${generator.locales.length} locales`);
+}

--- a/bin/generate-html.js
+++ b/bin/generate-html.js
@@ -1,35 +1,39 @@
 #! /usr/bin/env node
 "use strict";
+const defaults = {
+  locale: "en-US",
+  title: "New Tab",
+  cssPath: "./main.css",
+  jsPath: "./main.js",
+  localeDataPath: "./locale-data.js"
+};
 
-function template(options) {
-  const locale = options.locale;
-  const paths = options.paths;
-  const title = options.title;
+function template(rawOptions) {
+  const options = Object.assign({}, defaults, rawOptions || {});
   return `
 <!DOCTYPE html>
-<html lang="${locale}">
+<html lang="${options.locale}">
 <head>
   <meta charset="utf-8">
    <meta name="viewport" content="width=device-width user-scalable=no" />
-  <link rel="stylesheet" href="${paths.css}">
-  <title>${title}</title>
+  <link rel="stylesheet" href="${options.cssPath}">
+  <title>${options.title}</title>
 </head>
 <body>
   <div id="root"></div>
-  <script src="${paths.localeData}"></script>
-  <script src="${paths.js}"></script>
+  <script src="${options.localeDataPath}"></script>
+  <script src="${options.jsPath}"></script>
 </body>
 </html>
 `;
-}
+};
 
-process.stdout.write(template({
-  // todo: read from args
-  locale: "en-US",
-  title: "New Tab",
-  paths: {
-    css: "./main.css",
-    js: "./main.js",
-    localeData: "./locale-data.js"
-  }
-}));
+module.exports = template;
+
+if (require.main === module)  {
+  // called from command line
+  const args = require("minimist")(process.argv.slice(2), {
+    alias: {locale: "l", title: "t"}
+  });
+  process.stdout.write(template(args));
+}

--- a/bin/generate-locale-data.js
+++ b/bin/generate-locale-data.js
@@ -1,3 +1,4 @@
+#! /usr/bin/env node
 "use strict";
 const path = require("path");
 const fs = require("fs");
@@ -53,7 +54,16 @@ function generateFile(locale) {
   const baseLocale = locale.split("-")[0];
   const localeData = readLocaleDataFile(locale) || readLocaleDataFile(baseLocale) || defaultLocaleData;
   const messages = getMessages(locale) || getMessages(baseLocale) || defaultMessages;
-  return template({locale, messages, localeData});
+  return {
+    fileString: template({locale, messages, localeData}),
+    messages
+  };
 }
 
-process.stdout.write(generateFile(DEFAULT_LOCALE));
+module.exports = generateFile;
+
+if (require.main === module)  {
+  // called from command line
+  const args = require("minimist")(process.argv.slice(2), {alias: {locale: 'l'}});
+  process.stdout.write(generateFile(args.locale).fileString);
+}

--- a/package.json
+++ b/package.json
@@ -11,15 +11,13 @@
     "setup:static": "cp -r src/static/* www",
     "setup:fake": "touch www/main.js www/main.css",
     "setup:offline": "bin/generate-offline-files.js",
-
     "build": "npm run setup && npm-run-all build:*",
     "build:js": "NODE_ENV=production webpack -p --optimize-dedupe",
     "build:css": "node-sass src/main.scss -o www",
-
+    "postbuild": "node ./bin/generate-directories --static www -o build",
     "start": "npm run setup && npm-run-all --parallel watch:*",
     "watch:css": "npm run build:css && npm run build:css -- --source-map www/main.css.map -w -r",
     "watch:js": "webpack-dev-server --hot --port=1944 --content-base www",
-
     "test:travis": "karma start --reporters mocha,coverage,coveralls && npm run test:mocha",
     "test": "karma start && npm run test:mocha",
     "test:mocha": "mocha ./tests-node -R spec",
@@ -50,6 +48,7 @@
     "eslint-loader": "^1.1.1",
     "eslint-plugin-react": "^3.10.0",
     "fs-extra": "^0.26.2",
+    "glob": "^5.0.14",
     "handlebars": "^4.0.4",
     "html2js": "^0.2.0",
     "inject-loader": "^2.0.1",
@@ -72,6 +71,7 @@
     "karma-sourcemap-loader": "^0.3.6",
     "karma-webpack": "^1.7.0",
     "marcosc-async": "^1.0.2",
+    "minimist": "^1.2.0",
     "mocha": "^2.3.4",
     "mozilla-download": "^1.1.1",
     "nock": "^3.5.0",

--- a/tests-node/generate-html.test.js
+++ b/tests-node/generate-html.test.js
@@ -4,22 +4,39 @@ const child = require("child_process");
 const assert = require("chai").assert;
 
 const filepath = path.join(__dirname, "../bin/generate-html.js");
+const generateHTML = require("../bin/generate-html");
+
+function execute(args) {
+  const command = `node ${filepath} ${args || ""}`;
+  return child.execSync(command, {encoding: "utf8"});
+}
 
 describe("generateHTML", () => {
-  let result;
-  beforeEach(() => {
-    result = child.execSync(`node ${filepath}`, {encoding: "utf8"});
-  });
-
   it("should generate some html", () => {
-    assert.ok(result);
+    assert.ok(generateHTML());
+    assert.include(generateHTML(), `<html lang="en-US">`);
+    assert.include(generateHTML(), `<title>New Tab</title>`);
   });
   it("should render locale", () => {
-    assert.include(result, `<html lang="en-US">`);
+    assert.include(generateHTML({locale: "es-ES"}), `<html lang="es-ES">`);
   });
   it("should include file paths", () => {
+    const result = execute();
     assert.include(result, './locale-data.js');
     assert.include(result, './main.js');
     assert.include(result, './main.css');
+  });
+  describe("command line", () => {
+    it("should generate some html", () => {
+      assert.ok(execute());
+    });
+    it("should take locale as an arg", () => {
+      assert.include(execute("-l es-ES"), `<html lang="es-ES">`);
+      assert.include(execute("--locale es-ES"), `<html lang="es-ES">`);
+    });
+    it("should take title as an arg", () => {
+      assert.include(execute("-t foo"), `<title>foo</title>`);
+      assert.include(execute("--title foo"), `<title>foo</title>`);
+    });
   });
 });

--- a/tests-node/generate-locale-data.test.js
+++ b/tests-node/generate-locale-data.test.js
@@ -4,33 +4,52 @@ const child = require("child_process");
 const assert = require("chai").assert;
 
 const filepath = path.join(__dirname, "../bin/generate-locale-data.js");
+const generateLocaleData = require("../bin/generate-locale-data.js");
 
 function execute(args) {
-  return child.execSync(`node ${filepath}`, {input: args, encoding: "utf8"});
+  const command = `node ${filepath} ${args || ""}`;
+  return child.execSync(command, {encoding: "utf8"});
 }
 
 describe("generateLocaleData", () => {
-  let result;
-  let window;
-  beforeEach(() => {
-    window = {};
-    result = execute();
-    eval(result);
+  describe("programmatic", () => {
+    let result;
+    let window;
+    beforeEach(() => {
+      window = {};
+      result = generateLocaleData("en-US");
+      eval(result.fileString);
+    });
+
+    it("should generate an object with messages and file string", () => {
+      assert.ok(result);
+      assert.property(result, "fileString");
+      assert.property(result, "messages");
+    });
+
+    it("should add newTabLocaleInfo to window", () => {
+      assert.property(window, 'newTabLocaleInfo');
+      assert.property(window.newTabLocaleInfo, 'locale');
+      assert.property(window.newTabLocaleInfo, 'messages');
+      assert.isObject(window.newTabLocaleInfo.messages);
+    });
+
+    it("should add reactIntlData to window", () => {
+      assert.property(window, 'reactIntlLocaleData');
+      assert.isArray(window.reactIntlLocaleData);
+    });
+  });
+  describe("command line", () => {
+    it("should generate some js", () => {
+      const result = execute();
+      assert.include(result, "window.newTabLocaleInfo");
+      assert.include(result, "window.reactIntlLocaleData");
+    });
+    it("should take locale or l as an arg", () => {
+      assert.include(execute("--locale es-ES"), `window.newTabLocaleInfo = {locale: "es-ES"`);
+      assert.include(execute("--l es-ES"), `window.newTabLocaleInfo = {locale: "es-ES"`);
+    });
   });
 
-  it("should generate some js", () => {
-    assert.ok(result);
-  });
 
-  it("should add newTabLocaleInfo to window", () => {
-    assert.property(window, 'newTabLocaleInfo');
-    assert.property(window.newTabLocaleInfo, 'locale');
-    assert.property(window.newTabLocaleInfo, 'messages');
-    assert.isObject(window.newTabLocaleInfo.messages);
-  });
-
-  it("should add reactIntlData to window", () => {
-    assert.property(window, 'reactIntlLocaleData');
-    assert.isArray(window.reactIntlLocaleData);
-  });
 });


### PR DESCRIPTION
This generates a build for all locales and channels in `/build` when `npm run build` is run.

The `npm start` task still uses the `www` directory and only outputs en-US.
